### PR TITLE
Event class and object attribute observable validation. Explicit category validation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ poetry install
 
 Before committing, run the formatters and tests:
 ```
-poetry run isort
-poetry run black
+poetry run isort .
+poetry run black .
 poetry run pyright
 poetry run pytest
 ```

--- a/ocsf_validator/__main__.py
+++ b/ocsf_validator/__main__.py
@@ -1,13 +1,14 @@
 from argparse import ArgumentParser
 
-from ocsf_validator.reader import FileReader, ReaderOptions
 from ocsf_validator.runner import ValidationRunner, ValidatorOptions
 
 parser = ArgumentParser(prog="ocsf-validator", description="OCSF Schema Validation")
-parser.add_argument("path", help="The OCSF schema root directory", action="store")
+parser.add_argument("path", help="The OCSF schema root directory")
+parser.add_argument("-m", "--metaschema_path",
+                    help="The OCSF schema's metaschema (default: metaschema subdirectory of schema root)")
 args = parser.parse_args()
 
-opts = ValidatorOptions(base_path=args.path)
+opts = ValidatorOptions(base_path=args.path, metaschema_path=args.metaschema_path)
 
 validator = ValidationRunner(opts)
 

--- a/ocsf_validator/__main__.py
+++ b/ocsf_validator/__main__.py
@@ -4,8 +4,12 @@ from ocsf_validator.runner import ValidationRunner, ValidatorOptions
 
 parser = ArgumentParser(prog="ocsf-validator", description="OCSF Schema Validation")
 parser.add_argument("path", help="The OCSF schema root directory")
-parser.add_argument("-m", "--metaschema_path",
-                    help="The OCSF schema's metaschema (default: metaschema subdirectory of schema root)")
+parser.add_argument(
+    "-m",
+    "--metaschema_path",
+    help="The OCSF schema's metaschema"
+    " (default: metaschema subdirectory of schema root)",
+)
 args = parser.parse_args()
 
 opts = ValidatorOptions(base_path=args.path, metaschema_path=args.metaschema_path)

--- a/ocsf_validator/errors.py
+++ b/ocsf_validator/errors.py
@@ -239,3 +239,8 @@ class ObservableTypeIDCollisionError(ValidationError):
             f"Collision with observable type_id {type_id} between {this_def}"
             f" in file {file} and {', '.join(other_defs)}"
         )
+
+
+class UnknownCategoryError(ValidationError):
+    def __init__(self, category: str, file: str):
+        super().__init__(f'Unknown category "{category}" in "{file}"')

--- a/ocsf_validator/processor.py
+++ b/ocsf_validator/processor.py
@@ -4,9 +4,15 @@ from typing import Any, Callable, Optional
 from ocsf_validator.errors import *
 from ocsf_validator.reader import Reader
 from ocsf_validator.type_mapping import TypeMapping
-from ocsf_validator.types import (ATTRIBUTES_KEY, EXTENDS_KEY, INCLUDE_KEY,
-                                  PROFILES_KEY, OcsfDictionary, OcsfEvent,
-                                  OcsfObject)
+from ocsf_validator.types import (
+    ATTRIBUTES_KEY,
+    EXTENDS_KEY,
+    INCLUDE_KEY,
+    PROFILES_KEY,
+    OcsfDictionary,
+    OcsfEvent,
+    OcsfObject,
+)
 
 
 def deep_merge(
@@ -64,7 +70,8 @@ class DependencyResolver:
 
         for file in filenames:
             if relative_to is not None:
-                # Search extension for relative include path, e.g. /includes/thing.json -> /extensions/stuff/includes/thing.json
+                # Search extension for relative include path,
+                # e.g. /includes/thing.json -> /extensions/stuff/includes/thing.json
                 extn = self._types.extension(relative_to)
                 if extn is not None:
                     k = self._reader.key("extensions", extn, file)
@@ -247,8 +254,10 @@ class ExtendsParser(MergeParser):
 class ProfilesParser(MergeParser):
     def applies_to(self, t: type) -> bool:
         if hasattr(t, "__required_keys__") or hasattr(t, "__optional_keys"):
-            return PROFILES_KEY in t.__required_keys__ or PROFILES_KEY in t.__optional_keys__  # type: ignore
-
+            return (
+                PROFILES_KEY in t.__required_keys__
+                or PROFILES_KEY in t.__optional_keys__  # type: ignore
+            )
         else:
             return False
 
@@ -275,7 +284,10 @@ class ProfilesParser(MergeParser):
 class AttributesParser(MergeParser):
     def applies_to(self, t: type) -> bool:
         if hasattr(t, "__required_keys__") or hasattr(t, "__optional_keys"):
-            return ATTRIBUTES_KEY in t.__required_keys__ or ATTRIBUTES_KEY in t.__optional_keys__  # type: ignore
+            return (
+                ATTRIBUTES_KEY in t.__required_keys__
+                or ATTRIBUTES_KEY in t.__optional_keys__  # type: ignore
+            )
         else:
             return False
 
@@ -308,7 +320,8 @@ class AttributesParser(MergeParser):
         root = self._root_dict()
         extn = self._extn_dict(path)
 
-        # TODO is the dict name comparison enough or do we need to find by the `name` key?
+        # TODO is the dict name comparison enough
+        #      or do we need to find by the `name` key?
         for name, attr in attrs.items():
             if name in extn:
                 deep_merge(attrs[name], extn[name])
@@ -318,7 +331,13 @@ class AttributesParser(MergeParser):
 
 class IncludeParser(MergeParser):
     def applies_to(self, t: type) -> bool:
-        return ("__required_keys__" in t.__dict__ and INCLUDE_KEY in t.__required_keys__) or ("__optional_keys__" in t.__dict__ and INCLUDE_KEY in t.__optional_keys__)  # type: ignore
+        return (
+            "__required_keys__" in t.__dict__
+            and INCLUDE_KEY in t.__required_keys__  # type: ignore
+        ) or (
+            "__optional_keys__" in t.__dict__
+            and INCLUDE_KEY in t.__optional_keys__  # type: ignore
+        )
 
     def _has_includes(self, defn: dict[str, Any]) -> bool:
         """Recursively search for $include directives."""

--- a/ocsf_validator/reader.py
+++ b/ocsf_validator/reader.py
@@ -58,7 +58,9 @@ class Reader(ABC):
                     path = Path(options)
                 else:
                     path = options
-                options = ReaderOptions(base_path=path, metaschema_path=(path / "metaschema"))
+                options = ReaderOptions(
+                    base_path=path, metaschema_path=(path / "metaschema")
+                )
 
             self._options = options
         else:
@@ -160,7 +162,9 @@ class DictReader(Reader):
 
     Useful (hopefully) for testing and debugging."""
 
-    def __init__(self, options: ReaderOptions | Pathable | SchemaData | None = None) -> None:
+    def __init__(
+        self, options: ReaderOptions | Pathable | SchemaData | None = None
+    ) -> None:
         if isinstance(options, dict):
             super().__init__(None)
             self.set_data(options)

--- a/ocsf_validator/reader.py
+++ b/ocsf_validator/reader.py
@@ -6,16 +6,13 @@ access to the OCSF schema as its represented in the definition files.
 """
 
 import json
-import re
 from abc import ABC
 from dataclasses import dataclass
-from enum import IntEnum
-from pathlib import Path, PurePath
+from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, Optional
 
 from ocsf_validator.errors import InvalidBasePathError
 from ocsf_validator.matchers import Matcher
-from ocsf_validator.types import *
 
 # TODO would os.PathLike be better?
 Pathable = str | Path
@@ -32,6 +29,9 @@ class ReaderOptions:
 
     base_path: Optional[Path] = None
     """The base path from which to load the schema."""
+
+    metaschema_path: Optional[Path] = None
+    """The metaschema path from which to load the metaschema."""
 
     read_extensions: bool = True
     """Recurse extensions."""
@@ -58,7 +58,7 @@ class Reader(ABC):
                     path = Path(options)
                 else:
                     path = options
-                options = ReaderOptions(base_path=path)
+                options = ReaderOptions(base_path=path, metaschema_path=(path / "metaschema"))
 
             self._options = options
         else:
@@ -70,6 +70,10 @@ class Reader(ABC):
     @property
     def base_path(self):
         return self._options.base_path
+
+    @property
+    def metaschema_path(self):
+        return self._options.metaschema_path
 
     def contents(self, path: Pathable) -> SchemaData:
         """Retrieve the parsed JSON data in a given file."""
@@ -155,6 +159,13 @@ class DictReader(Reader):
     """A Reader that works from a `dict` without reading the filesystem.
 
     Useful (hopefully) for testing and debugging."""
+
+    def __init__(self, options: ReaderOptions | Pathable | SchemaData | None = None) -> None:
+        if isinstance(options, dict):
+            super().__init__(None)
+            self.set_data(options)
+        else:
+            super().__init__(options)
 
     def set_data(self, data: SchemaData):
         self._data = data.copy()

--- a/ocsf_validator/runner.py
+++ b/ocsf_validator/runner.py
@@ -1,5 +1,5 @@
-"""Validate OCSF Schema definitions.
-
+"""
+Validate OCSF Schema definitions.
 """
 
 import traceback
@@ -70,7 +70,8 @@ class ValidatorOptions:
     """An `extends` inheritance target is missing."""
 
     imprecise_inheritance: int = Severity.INFO
-    """An `extends` inheritance target is resolvable but imprecise and possibly ambiguous."""
+    """An `extends` inheritance target is resolvable
+    but imprecise and possibly ambiguous."""
 
     missing_key: int = Severity.ERROR
     """A required key is missing."""
@@ -241,12 +242,17 @@ class ValidationRunner:
 
         try:
             print(self.txt_emphasize("===[ OCSF Schema Validator ]==="))
-            print("Validating OCSF Schema at:", self.txt_highlight(self.options.base_path))
+            print(
+                "Validating OCSF Schema at:", self.txt_highlight(self.options.base_path)
+            )
             b_path = Path(self.options.base_path)
             if not b_path.is_absolute():
                 print("  Absolute path:", str(b_path.resolve()))
             if self.options.metaschema_path is not None:
-                print("Using metaschema at:", self.txt_highlight(self.options.metaschema_path))
+                print(
+                    "Using metaschema at:",
+                    self.txt_highlight(self.options.metaschema_path),
+                )
                 m_path = Path(self.options.metaschema_path)
                 if not m_path.is_absolute():
                     print("  Absolute path:", str(m_path.resolve()))
@@ -336,7 +342,9 @@ class ValidationRunner:
 
             test(
                 "Event class categories are defined",
-                lambda: validate_event_categories(reader, collector=collector, types=types),
+                lambda: validate_event_categories(
+                    reader, collector=collector, types=types
+                ),
             )
 
             test(

--- a/ocsf_validator/runner.py
+++ b/ocsf_validator/runner.py
@@ -16,6 +16,7 @@ from ocsf_validator.reader import FileReader, ReaderOptions
 from ocsf_validator.type_mapping import TypeMapping
 from ocsf_validator.validators import (
     validate_attr_types,
+    validate_event_categories,
     validate_include_targets,
     validate_intra_type_collisions,
     validate_metaschemas,
@@ -40,6 +41,9 @@ class ValidatorOptions:
 
     base_path: str = "."
     """The base path of the schema."""
+
+    metaschema_path: str = None
+    """The path to the schema's metaschema."""
 
     extensions: bool = True
     """Include the contents of extensions."""
@@ -107,6 +111,9 @@ class ValidatorOptions:
     observable_collision: int = Severity.ERROR
     """Colliding observable type_id defined."""
 
+    unknown_category: int = Severity.ERROR
+    """Unknown category."""
+
     def severity(self, err: Exception):
         match type(err):
             case errors.MissingRequiredKeyError:
@@ -147,6 +154,8 @@ class ValidatorOptions:
                 return self.illegal_observable
             case errors.ObservableTypeIDCollisionError:
                 return self.observable_collision
+            case errors.UnknownCategoryError:
+                return self.unknown_category
             case _:
                 return Severity.INFO
 
@@ -232,13 +241,25 @@ class ValidationRunner:
 
         try:
             print(self.txt_emphasize("===[ OCSF Schema Validator ]==="))
-            print(
-                "Validating OCSF Schema at", self.txt_highlight(self.options.base_path)
-            )
+            print("Validating OCSF Schema at:", self.txt_highlight(self.options.base_path))
+            b_path = Path(self.options.base_path)
+            if not b_path.is_absolute():
+                print("  Absolute path:", str(b_path.resolve()))
+            if self.options.metaschema_path is not None:
+                print("Using metaschema at:", self.txt_highlight(self.options.metaschema_path))
+                m_path = Path(self.options.metaschema_path)
+                if not m_path.is_absolute():
+                    print("  Absolute path:", str(m_path.resolve()))
 
             # Setup the reader
+            base_path = Path(self.options.base_path)
+            if self.options.metaschema_path is None:
+                metaschema_path = base_path / "metaschema"
+            else:
+                metaschema_path = Path(self.options.metaschema_path)
             opts = ReaderOptions(
-                base_path=Path(self.options.base_path),
+                base_path=base_path,
+                metaschema_path=metaschema_path,
                 read_extensions=self.options.extensions,
             )
             reader = None
@@ -311,6 +332,11 @@ class ValidationRunner:
             test(
                 "Attribute type references are defined",
                 lambda: validate_attr_types(reader, collector=collector, types=types),
+            )
+
+            test(
+                "Event class categories are defined",
+                lambda: validate_event_categories(reader, collector=collector, types=types),
             )
 
             test(

--- a/ocsf_validator/types.py
+++ b/ocsf_validator/types.py
@@ -11,6 +11,7 @@ from typing import (
 )
 
 ATTRIBUTES_KEY = "attributes"
+CATEGORY_KEY = "category"
 PROFILES_KEY = "profiles"
 EXTENDS_KEY = "extends"
 INCLUDE_KEY = "$include"
@@ -131,6 +132,7 @@ OcsfObject = TypedDict(
         "observable": NotRequired[int],
         "profiles": NotRequired[Sequence[str]],
         "constraints": NotRequired[Dict[str, Sequence[str]]],
+        "observables": NotRequired[Dict[str, int]],
         "$include": NotRequired[Union[str, Sequence[str]]],
         "@deprecated": NotRequired[OcsfDeprecationInfo],
     },

--- a/ocsf_validator/validators.py
+++ b/ocsf_validator/validators.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path, PurePath
-from typing import Callable
+from typing import Any, Callable, Dict, List, Optional
 
 import jsonschema
 import referencing
@@ -17,6 +17,7 @@ from ocsf_validator.errors import (
     TypeNameCollisionError,
     UndefinedAttributeError,
     UndetectableTypeError,
+    UnknownCategoryError,
     UnknownKeyError,
     UnusedAttributeError,
 )
@@ -33,7 +34,18 @@ from ocsf_validator.matchers import (
 from ocsf_validator.processor import process_includes
 from ocsf_validator.reader import Reader
 from ocsf_validator.type_mapping import TypeMapping
-from ocsf_validator.types import *
+from ocsf_validator.types import (
+    ATTRIBUTES_KEY,
+    CATEGORY_KEY,
+    INCLUDE_KEY,
+    OBSERVABLE_KEY,
+    OBSERVABLES_KEY,
+    TYPES_KEY,
+    OcsfEvent,
+    OcsfObject,
+    is_ocsf_type,
+    leaf_type,
+)
 
 
 def validate_required_keys(
@@ -245,7 +257,7 @@ def validate_intra_type_collisions(
 
 def _default_get_registry(reader: Reader, base_uri: str) -> referencing.Registry:
     registry = referencing.Registry()
-    for schema_file_path in (reader.base_path / "metaschema").rglob("*.schema.json"):
+    for schema_file_path in reader.metaschema_path.glob("*.schema.json"):
         with open(schema_file_path, "r") as file:
             schema = json.load(file)
             resource = referencing.Resource.from_contents(schema)
@@ -378,10 +390,41 @@ def validate_observables(
     NOTE: This must be called _before_ merging extends to avoid incorrectly detecting collisions between
           parent and child classes and objects -- specifically before runner.process_includes.
     """
-    # Map of observables type_ids to list of definitions
-    observables: Dict[int, list[str]] = {}
+    observables = validate_and_get_observables(reader, collector)
+    return observables_to_string(observables)
 
-    def check_collision(type_id, name, file):
+
+# Factored out to a function for unit testing
+def observables_to_string(observables: Dict[Any, List[str]]) -> str:
+    strs = ["   Observables:"]
+    # Supplying key function is needed for when type_ids are incorrectly defined as something other than ints
+    type_ids = sorted(observables.keys(), key=_lenient_to_int)
+    for tid in type_ids:
+        collision = ""
+        if len(observables[tid]) > 1:
+            collision = "💥COLLISION💥 "
+        strs.append(f'   {tid:7} →️ {collision}{", ".join(observables[tid])}')
+    return "\n".join(strs)
+
+
+def _lenient_to_int(value) -> int:
+    try:
+        return int(value)
+    except ValueError:
+        return -1
+
+
+def validate_and_get_observables(
+    reader: Reader,
+    collector: Collector = Collector.default
+) -> Dict[Any, List[str]]:
+    """
+    Actual validation implementation. This exists so unit tests can interrogate the generated `observables` dictionary.
+    """
+    # Map of observable type_ids to list of definitions
+    observables: Dict[Any, List[str]] = {}
+
+    def check_collision(type_id: Any, name: str, file: str) -> None:
         if type_id in observables:
             definitions = observables[type_id]
             collector.handle(
@@ -391,78 +434,143 @@ def validate_observables(
         else:
             observables[type_id] = [name]
 
-    def check_item_maybe_observable(item, kind, file):
-        if OBSERVABLE_KEY in item:
-            type_id = item[OBSERVABLE_KEY]
-            name = f"{item.get('caption')} ({kind})"
-            check_collision(type_id, name, file)
+    def any_attribute_has_observable(source: Dict[str, Any]) -> bool:
+        # Returns true if any attribute defines an observable
+        if ATTRIBUTES_KEY in source:
+            for item in source[ATTRIBUTES_KEY].values():
+                if OBSERVABLE_KEY in item:
+                    return True
+        return False
 
-    def validate_dictionaries(reader: Reader, file: str):
-        if TYPES_KEY in reader[file] and ATTRIBUTES_KEY in reader[file][TYPES_KEY]:
-            for t_key in reader[file][TYPES_KEY][ATTRIBUTES_KEY]:
-                check_item_maybe_observable(
-                    reader[file][TYPES_KEY][ATTRIBUTES_KEY][t_key],
-                    "Dictionary Type",
-                    file,
+    def check_attributes(source: Dict[str, Any], name_fn: Callable[[str, Dict[str, Any]], str], file: str):
+        if ATTRIBUTES_KEY in source:
+            for a_key, item in source[ATTRIBUTES_KEY].items():
+                if OBSERVABLE_KEY in item:
+                    check_collision(item[OBSERVABLE_KEY], name_fn(a_key, item), file)
+
+    def validate_dictionaries(reader: Reader, file: str) -> None:
+        if TYPES_KEY in reader[file]:
+            check_attributes(reader[file][TYPES_KEY],
+                             lambda a_key, item: f"{item.get('caption')} (Dictionary Type)",
+                             file)
+
+        check_attributes(reader[file],
+                         lambda a_key, item: f"{item.get('caption')} (Dictionary Attribute)",
+                         file)
+
+    def validate_objects(reader: Reader, file: str) -> None:
+        # Special-case: the "observable" object model's type_id enum has the base for observable type_id
+        # typically defining 0: "Unknown" and 99: "Other", which are otherwise not defined.
+        if (reader[file].get("name") == "observable"
+                and ATTRIBUTES_KEY in reader[file]
+                and "type_id" in reader[file][ATTRIBUTES_KEY]
+                and "enum" in reader[file][ATTRIBUTES_KEY]["type_id"]):
+            enum_dict = reader[file][ATTRIBUTES_KEY]["type_id"]["enum"]
+            for observable_type_id_str, enum in enum_dict.items():
+                name = enum.get("caption", f"Observable enum {observable_type_id_str}")
+                check_collision(int(observable_type_id_str), name, file)
+
+        # Check for illegal definition in "hidden" objects. Hidden (or "intermediate") objects are those that are not
+        # a "special extends" case, and the name has a leading underscore.
+        if (not _is_special_extends(reader[file])
+                and "name" in reader[file]
+                and PurePath(reader[file]["name"]).name.startswith("_")):
+            if OBSERVABLE_KEY in reader[file]:
+                cause = (
+                    f'Illegal "{OBSERVABLE_KEY}" definition in hidden object, file "{file}":'
+                    f' defining top-level observable in a hidden object (name with leading underscore)'
+                    f' causes collisions in child objects'
                 )
+                collector.handle(IllegalObservableTypeIDError(cause))
 
-        if ATTRIBUTES_KEY in reader[file]:
-            for a_key in reader[file][ATTRIBUTES_KEY]:
-                check_item_maybe_observable(
-                    reader[file][ATTRIBUTES_KEY][a_key], "Dictionary Attribute", file
+            if any_attribute_has_observable(reader[file]):
+                cause = (
+                    f'Illegal definition of one or more attributes with "{OBSERVABLE_KEY}" in hidden object,'
+                    f' file "{file}": defining attribute observables in a hidden object'
+                    f' (name with leading underscore) causes collisions in child objects'
                 )
+                collector.handle(IllegalObservableTypeIDError(cause))
 
-    def validate_objects(reader: Reader, file: str):
-        # Only check for illegal definition in objects with "name"
-        # (ignore weird objects with no name that do some kind of reverse inheritance)
-        # and
-        if (
-            "name" in reader[file]
-            and PurePath(file).name.startswith("_")
-            and OBSERVABLE_KEY in reader[file]
-        ):
-            cause = (
-                f'Illegal "{OBSERVABLE_KEY}" definition in hidden object, file "{file}":'
-                f" defining observable in a hidden object (name with leading underscore)"
-                f" causes collisions in child objects"
-            )
-            collector.handle(IllegalObservableTypeIDError(cause))
+        # Check top-level observable -- entire object is an observable
+        if OBSERVABLE_KEY in reader[file]:
+            check_collision(reader[file][OBSERVABLE_KEY], f"{reader[file].get('caption')} (Object)", file)
 
-        # Check for collisions in all objects
-        check_item_maybe_observable(reader[file], "Object", file)
+        # Check object-specific attributes
+        check_attributes(
+            reader[file],
+            lambda a_key, item:  f"{reader[file].get('caption')} Object: {a_key} (Object-Specific Attribute)",
+            file)
 
-    def validate_classes(reader: Reader, file: str):
-        # Only check for illegal definition in classes with "name"
-        # (ignore weird classes with no name that do some kind of reverse inheritance)
-        if (
-            "name" in reader[file]
-            and "base_event" != reader[file].get("name")
-            and "uid" not in reader[file]
-            and OBSERVABLES_KEY in reader[file]
-        ):
-            cause = (
-                f'Illegal "{OBSERVABLES_KEY}" definition in hidden class, file "{file}":'
-                f' defining observables in a hidden class (classes other than "base_event" without a "uid")'
-                f" causes collisions in child classes"
-            )
-            collector.handle(IllegalObservableTypeIDError(cause))
+    def validate_classes(reader: Reader, file: str) -> None:
+        # Classes do not have top-level "observable" attribute -- you can't specify an entire class as an observable.
 
-        # Check for collisions in all classes
+        # Check for illegal definition in "hidden" classes. Hidden (or "intermediate") classes are those that are not
+        # a "special extends" case, the name isn't "base_class", and class doesn't have a "uid".
+        if (not _is_special_extends(reader[file])
+                and "base_event" != reader[file].get("name")
+                and "uid" not in reader[file]):
+            if OBSERVABLES_KEY in reader[file]:
+                cause = (
+                    f'Illegal "{OBSERVABLES_KEY}" definition in hidden class, file "{file}":'
+                    f' defining attribute path based observables in a hidden class'
+                    f' (classes other than "base_event" without a "uid") causes collisions in child classes'
+                )
+                collector.handle(IllegalObservableTypeIDError(cause))
+
+            if any_attribute_has_observable(reader[file]):
+                cause = (
+                    f'Illegal definition of attribute with "{OBSERVABLE_KEY}" in hidden class, file "{file}":'
+                    f' defining attribute observables in a hidden class'
+                    f' (classes other than "base_event" without a "uid") causes collisions in child classes'
+                )
+                collector.handle(IllegalObservableTypeIDError(cause))
+
+        # Check class-specific attributes
+        check_attributes(
+            reader[file],
+            lambda a_key, item:  f"{reader[file].get('caption')} Class: {a_key} (Class-Specific Attribute)",
+            file)
+
+        # Check class-specific attribute path observables
         if OBSERVABLES_KEY in reader[file]:
             for attribute_path in reader[file][OBSERVABLES_KEY]:
-                type_id = reader[file][OBSERVABLES_KEY][attribute_path]
-                name = f"{reader[file]['caption']} Class: {attribute_path} (Class-Specific)"
-                check_collision(type_id, name, file)
+                check_collision(reader[file][OBSERVABLES_KEY][attribute_path],
+                                f"{reader[file]['caption']} Class: {attribute_path} (Class-Specific Attribute Path)",
+                                file)
 
     reader.apply(validate_dictionaries, DictionaryMatcher())
     reader.apply(validate_objects, ObjectMatcher())
     reader.apply(validate_classes, EventMatcher())
 
-    strs = ["   Observables:"]
-    type_ids = sorted(observables.keys())
-    for tid in type_ids:
-        collision = ""
-        if len(observables[tid]) > 1:
-            collision = "💥COLLISION💥 "
-        strs.append(f'   {tid:6} →️ {collision}{", ".join(observables[tid])}')
-    return "\n".join(strs)
+    return observables
+
+
+def _is_special_extends(item):
+    """
+    Returns True if class or object is a "special extends", which is a weird reverse extends allowing extensions to
+    modify core schema classes and objects.
+    """
+    name = item.get("name")
+    if name is None:
+        name = item.get("extends")
+    return name == item.get("extends")
+
+
+def validate_event_categories(
+    reader: Reader,
+    collector: Collector = Collector.default,
+    types: Optional[TypeMapping] = None,
+):
+    # Initialize categories list with "other" since it isn't defined in categories.json
+    categories = {"other"}
+
+    def gather_categories(reader: Reader, file: str) -> None:
+        if ATTRIBUTES_KEY in reader[file]:
+            categories.update(reader[file][ATTRIBUTES_KEY].keys())
+
+    def validate_classes(reader: Reader, file: str) -> None:
+        if CATEGORY_KEY in reader[file] and reader[file][CATEGORY_KEY] not in categories:
+            collector.handle(UnknownCategoryError(reader[file][CATEGORY_KEY], file))
+
+    reader.apply(gather_categories, CategoriesMatcher())
+    reader.apply(validate_classes, EventMatcher())

--- a/ocsf_validator/validators.py
+++ b/ocsf_validator/validators.py
@@ -483,10 +483,10 @@ def validate_and_get_observables(
                 check_collision(int(observable_type_id_str), name, file)
 
         # Check for illegal definition in "hidden" objects. Hidden (or "intermediate")
-        # objects are those that are not a "special extends" case, and the name has a
+        # objects are those that are not a patch extends case, and the name has a
         # leading underscore.
         if (
-            not _is_special_extends(reader[file])
+            not _is_patch_extends(reader[file])
             and "name" in reader[file]
             and PurePath(reader[file]["name"]).name.startswith("_")
         ):
@@ -529,10 +529,10 @@ def validate_and_get_observables(
         # entire class as an observable.
 
         # Check for illegal definition in "hidden" classes. Hidden (or "intermediate")
-        # classes are those that are not a "special extends" case, the name isn't
+        # classes are those that are not a patch extends case, the name isn't
         # "base_class", and class doesn't have a "uid".
         if (
-            not _is_special_extends(reader[file])
+            not _is_patch_extends(reader[file])
             and "base_event" != reader[file].get("name")
             and "uid" not in reader[file]
         ):
@@ -579,10 +579,10 @@ def validate_and_get_observables(
     return observables
 
 
-def _is_special_extends(item):
+def _is_patch_extends(item):
     """
-    Returns True if class or object is a "special extends", which is a weird reverse
-    extends allowing extensions to modify core schema classes and objects.
+    Returns True if class or object is a "special" patch extends, which allows
+    extensions to modify core schema classes and objects.
     """
     name = item.get("name")
     if name is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,12 @@
 [tool.poetry]
 name = "ocsf-validator"
-version = "0.1.5"
+version = "0.1.6"
 description = "OCSF Schema Validation"
-authors = ["Jeremy Fisher <jeremy@query.ai>", "Alan Pinkert <apinkert@cisco.com>"]
+authors = [
+    "Jeremy Fisher <jeremy@query.ai>",
+    "Alan Pinkert <apinkert@cisco.com>",
+    "Rick Mouritzen <rmouritzen@splunk.com>",
+]
 readme = "README.md"
 packages = [{include = "ocsf_validator"}]
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,7 +1,5 @@
 import pytest
-import referencing
 
-from ocsf_validator.errors import *
 from ocsf_validator.reader import DictReader
 from ocsf_validator.validators import *
 
@@ -146,6 +144,7 @@ def test_validate_intra_type_collisions():
     # no error
     validate_intra_type_collisions(r)
 
+
 def test_validate_attr_keys():
     r = DictReader()
     r.set_data(
@@ -175,9 +174,160 @@ def test_validate_attr_keys():
     validate_attr_types(r)
 
     r["/objects/thing2.json"]["name"] = "thing3"
-    with pytest.raises(InvalidAttributeTypeError) as exc:
+    with pytest.raises(InvalidAttributeTypeError):
         validate_attr_types(r)
 
+
+def test_validate_observables():
+    good_data = {
+        "dictionary.json": {
+            "attributes": {
+                "name": {"caption": "Name", "type": "string_t"},
+                "alpha": {"caption": "Alpha", "type": "string_t"},
+                "beta": {"caption": "Beta", "type": "string_t"},
+                "gamma": {"caption": "Gamma", "type": "gamma_t", "observable": 1},
+                "delta": {"caption": "Delta", "type": "delta_t"},
+            },
+            "types": {
+                "attributes": {
+                    "string_t": {"caption": "String"},
+                    "integer_t": {"caption": "Integer"},
+                    "gamma_t": {"caption": "Gamma_T", "type": "string_t", "type_name": "String"},
+                    "delta_t": {"caption": "Delta_T", "type": "integer_t", "type_name": "Integer", "observable": 2},
+                },
+            }
+        },
+
+        "/objects/bird.json": {
+            "name": "bird",
+            "caption": "Bird",
+            "attributes": {
+                "name": {"requirement": "required"},
+                "alpha": {"requirement": "required"},
+            }
+        },
+        "/objects/cat.json": {
+            "name": "cat",
+            "caption": "Cat",
+            "observable": 10,
+            "attributes": {
+                "name": {"requirement": "required"},
+                "alpha": {"requirement": "required"}
+            }
+        },
+        "/objects/dog.json": {
+            "name": "dog",
+            "caption": "Dog",
+            "attributes": {
+                "name": {"requirement": "required"},
+                "alpha": {"requirement": "required", "observable": 11},
+            }
+        },
+        "/objects/dog_house.json": {
+            "name": "dog_house",
+            "caption": "Dog House",
+            "attributes": {
+                "tenant": {"type": "dog", "requirement": "required"}
+            },
+            "observables": {
+                "dog.name": 12
+            }
+        },
+
+        "/events/blue.json": {
+            "uid": 1,
+            "name": "blue",
+            "caption": "Blue",
+        },
+        "/events/green.json": {
+            "uid": 2,
+            "name": "green",
+            "caption": "Green",
+            "observable": 100,
+        },
+        "/events/red.json": {
+            "uid": 3,
+            "name": "red",
+            "caption": "Red",
+            "attributes": {
+                "beta": {"requirement": "required", "observable": 101}
+            }
+        },
+        "/events/yellow.json": {
+            "uid": 4,
+            "name": "yellow",
+            "caption": "Yellow",
+            "attributes": {
+                "bird": {"requirement": "required"}
+            },
+            "observables": {
+                "bird.name": 102
+            }
+        },
+    }
+
+    observables = validate_and_get_observables(DictReader(good_data))
+    assert observables is not None
+    assert len(observables) == 7
+    print("\ntest_validate_observables - collected observables:")
+    print(observables_to_string(observables))
+
+    with pytest.raises(IllegalObservableTypeIDError):
+        bad_data = dict(good_data)
+        bad_data["/objects/_hidden.json"] = {"name": "_hidden", "caption": "Hidden", "observable": 1}
+        validate_observables(DictReader(bad_data))
+
+    with pytest.raises(IllegalObservableTypeIDError):
+        bad_data = dict(good_data)
+        bad_data["/objects/_hidden.json"] = {
+            "name": "_hidden",
+            "caption": "Hidden",
+            "attributes": {
+                "beta": {"requirement": "required", "observable": 1}
+            }
+        }
+        validate_observables(DictReader(bad_data))
+
+    with pytest.raises(IllegalObservableTypeIDError):
+        bad_data = dict(good_data)
+        bad_data["/events/_hidden.json"] = {
+            "name": "hidden",
+            "caption": "Hidden",
+            "attributes": {
+                "beta": {"requirement": "required", "observable": 1}
+            }
+        }
+        validate_observables(DictReader(bad_data))
+
+    with pytest.raises(ObservableTypeIDCollisionError):
+        bad_data = dict(good_data)
+        dictionary_attributes = bad_data["dictionary.json"]["attributes"]
+        dictionary_attributes["epsilon"] = {"caption": "Epsilon", "type": "string_t", "observable": 1}
+        validate_observables(DictReader(bad_data))
+
+    with pytest.raises(ObservableTypeIDCollisionError):
+        bad_data = dict(good_data)
+        dictionary_types_attributes = bad_data["dictionary.json"]["types"]["attributes"]
+        dictionary_types_attributes["epsilon_t"] = {
+            "caption": "Epsilon_T", "type": "string_t", "type_name": "String", "observable": 2
+        },
+        validate_observables(DictReader(bad_data))
+
+
+def test_validate_event_categories():
+    good_data = {
+        "categories.json": {
+            "attributes": {
+                "alpha": {"caption": "Alpha", "uid": 1},
+                "beta": {"caption": "Beta", "uid": 2},
+            }
+        },
+        "events/foo.json": {"caption": "Foo", "category": "alpha"},
+        "events/bar.json": {"caption": "Bar", "category": "beta"},
+        "events/baz.json": {"caption": "Baz", "category": "other"},
+        "events/guux.json": {"caption": "Quux"},
+    }
+    validate_event_categories(DictReader(good_data))
 
 
 def test_validate_metaschemas():

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -192,19 +192,27 @@ def test_validate_observables():
                 "attributes": {
                     "string_t": {"caption": "String"},
                     "integer_t": {"caption": "Integer"},
-                    "gamma_t": {"caption": "Gamma_T", "type": "string_t", "type_name": "String"},
-                    "delta_t": {"caption": "Delta_T", "type": "integer_t", "type_name": "Integer", "observable": 2},
+                    "gamma_t": {
+                        "caption": "Gamma_T",
+                        "type": "string_t",
+                        "type_name": "String",
+                    },
+                    "delta_t": {
+                        "caption": "Delta_T",
+                        "type": "integer_t",
+                        "type_name": "Integer",
+                        "observable": 2,
+                    },
                 },
-            }
+            },
         },
-
         "/objects/bird.json": {
             "name": "bird",
             "caption": "Bird",
             "attributes": {
                 "name": {"requirement": "required"},
                 "alpha": {"requirement": "required"},
-            }
+            },
         },
         "/objects/cat.json": {
             "name": "cat",
@@ -212,8 +220,8 @@ def test_validate_observables():
             "observable": 10,
             "attributes": {
                 "name": {"requirement": "required"},
-                "alpha": {"requirement": "required"}
-            }
+                "alpha": {"requirement": "required"},
+            },
         },
         "/objects/dog.json": {
             "name": "dog",
@@ -221,19 +229,14 @@ def test_validate_observables():
             "attributes": {
                 "name": {"requirement": "required"},
                 "alpha": {"requirement": "required", "observable": 11},
-            }
+            },
         },
         "/objects/dog_house.json": {
             "name": "dog_house",
             "caption": "Dog House",
-            "attributes": {
-                "tenant": {"type": "dog", "requirement": "required"}
-            },
-            "observables": {
-                "dog.name": 12
-            }
+            "attributes": {"tenant": {"type": "dog", "requirement": "required"}},
+            "observables": {"dog.name": 12},
         },
-
         "/events/blue.json": {
             "uid": 1,
             "name": "blue",
@@ -243,38 +246,35 @@ def test_validate_observables():
             "uid": 2,
             "name": "green",
             "caption": "Green",
-            "observable": 100,
         },
         "/events/red.json": {
             "uid": 3,
             "name": "red",
             "caption": "Red",
-            "attributes": {
-                "beta": {"requirement": "required", "observable": 101}
-            }
+            "attributes": {"beta": {"requirement": "required", "observable": 100}},
         },
         "/events/yellow.json": {
             "uid": 4,
             "name": "yellow",
             "caption": "Yellow",
-            "attributes": {
-                "bird": {"requirement": "required"}
-            },
-            "observables": {
-                "bird.name": 102
-            }
+            "attributes": {"bird": {"requirement": "required"}},
+            "observables": {"bird.name": 101},
         },
     }
 
     observables = validate_and_get_observables(DictReader(good_data))
     assert observables is not None
-    assert len(observables) == 7
+    assert len(observables) == 6
     print("\ntest_validate_observables - collected observables:")
     print(observables_to_string(observables))
 
     with pytest.raises(IllegalObservableTypeIDError):
         bad_data = dict(good_data)
-        bad_data["/objects/_hidden.json"] = {"name": "_hidden", "caption": "Hidden", "observable": 1}
+        bad_data["/objects/_hidden.json"] = {
+            "name": "_hidden",
+            "caption": "Hidden",
+            "observable": 1,
+        }
         validate_observables(DictReader(bad_data))
 
     with pytest.raises(IllegalObservableTypeIDError):
@@ -282,9 +282,7 @@ def test_validate_observables():
         bad_data["/objects/_hidden.json"] = {
             "name": "_hidden",
             "caption": "Hidden",
-            "attributes": {
-                "beta": {"requirement": "required", "observable": 1}
-            }
+            "attributes": {"beta": {"requirement": "required", "observable": 1}},
         }
         validate_observables(DictReader(bad_data))
 
@@ -293,24 +291,31 @@ def test_validate_observables():
         bad_data["/events/_hidden.json"] = {
             "name": "hidden",
             "caption": "Hidden",
-            "attributes": {
-                "beta": {"requirement": "required", "observable": 1}
-            }
+            "attributes": {"beta": {"requirement": "required", "observable": 1}},
         }
         validate_observables(DictReader(bad_data))
 
     with pytest.raises(ObservableTypeIDCollisionError):
         bad_data = dict(good_data)
         dictionary_attributes = bad_data["dictionary.json"]["attributes"]
-        dictionary_attributes["epsilon"] = {"caption": "Epsilon", "type": "string_t", "observable": 1}
+        dictionary_attributes["epsilon"] = {
+            "caption": "Epsilon",
+            "type": "string_t",
+            "observable": 1,
+        }
         validate_observables(DictReader(bad_data))
 
     with pytest.raises(ObservableTypeIDCollisionError):
         bad_data = dict(good_data)
         dictionary_types_attributes = bad_data["dictionary.json"]["types"]["attributes"]
-        dictionary_types_attributes["epsilon_t"] = {
-            "caption": "Epsilon_T", "type": "string_t", "type_name": "String", "observable": 2
-        },
+        dictionary_types_attributes["epsilon_t"] = (
+            {
+                "caption": "Epsilon_T",
+                "type": "string_t",
+                "type_name": "String",
+                "observable": 2,
+            },
+        )
         validate_observables(DictReader(bad_data))
 
 
@@ -329,6 +334,21 @@ def test_validate_event_categories():
     }
     validate_event_categories(DictReader(good_data))
 
+    bad_data = {
+        "categories.json": {
+            "attributes": {
+                "alpha": {"caption": "Alpha", "uid": 1},
+                "beta": {"caption": "Beta", "uid": 2},
+            }
+        },
+        "events/foo.json": {"caption": "Foo", "category": "alpha"},
+        "events/bar.json": {"caption": "Bar", "category": "gamma"},
+        "events/baz.json": {"caption": "Baz", "category": "other"},
+        "events/guux.json": {"caption": "Quux"},
+    }
+    with pytest.raises(UnknownCategoryError):
+        validate_event_categories(DictReader(bad_data))
+
 
 def test_validate_metaschemas():
     # set up a json schema that expects an object with a name property only
@@ -337,22 +357,13 @@ def test_validate_metaschemas():
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Object",
         "type": "object",
-        "required": [
-            "name"
-        ],
-        "properties": {
-            "name": {
-                "type": "string"
-            }
-        },
-        "additionalProperties": False
+        "required": ["name"],
+        "properties": {"name": {"type": "string"}},
+        "additionalProperties": False,
     }
 
     # set up a function to a create a registry in memory
-    expected_schemas = [
-        "object.schema.json",
-        "event.schema.json"
-    ]
+    expected_schemas = ["object.schema.json", "event.schema.json"]
 
     def _get_registry(reader, base_uri):
         registry = referencing.Registry()


### PR DESCRIPTION
Add validation of event class and object attribute observable definitions. 

Add explicit validation of event categories (rather than rely on hard coded categories in metaschema.) 

Add command line parameter to specific alternative location for metaschema, which makes validating test schemas against core schema's metadata possible. 

Improve observable validation by adding in initial type_id enum values from `objects/observable.json`. This makes the validation include the 0 -> Unknown and 99 -> Other type_id values. 

Add unit tests for observable validation and category validation.