### PR TITLE
Fixed metaschema validation

### DIFF
--- a/ocsf_validator/validators.py
+++ b/ocsf_validator/validators.py
@@ -48,6 +48,17 @@ from ocsf_validator.types import (
 )
 
 
+METASCHEMA_MATCHERS =  {
+    "event.schema.json": EventMatcher(),
+    "include.schema.json": IncludeMatcher(),
+    "object.schema.json": ObjectMatcher(),
+    "profile.schema.json": ProfileMatcher(),
+    "categories.schema.json": CategoriesMatcher(),
+    "dictionary.schema.json": DictionaryMatcher(),
+    "extension.schema.json": ExtensionMatcher(),
+}
+
+
 def validate_required_keys(
     reader: Reader,
     collector: Collector = Collector.default,
@@ -278,17 +289,8 @@ def validate_metaschemas(
 
     base_uri = "https://schemas.ocsf.io/"
     registry = get_registry(reader, base_uri)
-    matchers = {
-        "event.schema.json": EventMatcher(),
-        "include.schema.json": IncludeMatcher(),
-        "object.schema.json": ObjectMatcher(),
-        "profile.schema.json": ProfileMatcher(),
-        "categories.schema.json": CategoriesMatcher(),
-        "dictionary.schema.json": DictionaryMatcher(),
-        "extension.schema.json": ExtensionMatcher(),
-    }
 
-    for metaschema, matcher in matchers.items():
+    for metaschema, matcher in METASCHEMA_MATCHERS.items():
         try:
             schema = registry.resolver(base_uri).lookup(metaschema).contents
         except referencing.exceptions.Unresolvable as exc:
@@ -301,8 +303,7 @@ def validate_metaschemas(
             continue
 
         def validate(reader: Reader, file: str) -> None:
-            with open(Path(reader.base_path, file), "r") as f:
-                data = json.load(f)
+            data = reader.contents(file)
             validator = jsonschema.Draft202012Validator(schema, registry=registry)
             errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
             for error in errors:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ocsf_validator.reader import DictReader
+from ocsf_validator.reader import DictReader, ReaderOptions
 from ocsf_validator.validators import *
 
 d1 = {
@@ -353,7 +353,7 @@ def test_validate_event_categories():
 def test_validate_metaschemas():
     # set up a json schema that expects an object with a name property only
     object_json_schema = {
-        "$id": "https://schema.ocsf.io/object.schema.json",
+        "$id": "https://fake.schema.ocsf.io/object.schema.json",
         "$schema": "https://json-schema.org/draft/2020-12/schema",
         "title": "Object",
         "type": "object",
@@ -362,18 +362,17 @@ def test_validate_metaschemas():
         "additionalProperties": False,
     }
 
-    # set up a function to a create a registry in memory
-    expected_schemas = ["object.schema.json", "event.schema.json"]
-
-    def _get_registry(reader, base_uri):
+    def _get_registry(reader, base_uri) -> referencing.Registry:
         registry = referencing.Registry()
-        for schema in expected_schemas:
+        for schema in METASCHEMA_MATCHERS.keys():
             resource = referencing.Resource.from_contents(object_json_schema)
             registry = registry.with_resource(base_uri + schema, resource=resource)
         return registry
 
+    options = ReaderOptions(base_path='')
+
     # test that a bad schema fails validation
-    r = DictReader()
+    r = DictReader(options)
     r.set_data(
         {
             "/objects/thing.json": {
@@ -386,7 +385,7 @@ def test_validate_metaschemas():
         validate_metaschemas(r, get_registry=_get_registry)
 
     # test that a good schema passes validation
-    r = DictReader()
+    r = DictReader(options)
     r.set_data(
         {
             "/objects/thing.json": {
@@ -398,7 +397,7 @@ def test_validate_metaschemas():
     validate_metaschemas(r, get_registry=_get_registry)
 
     # test that a good schema passes validation
-    r = DictReader()
+    r = DictReader(options)
     r.set_data(
         {
             "/objects/thing.json": {


### PR DESCRIPTION
This PR fixes the logic for metaschema validation, so that it properly uses the `Reader`'s definition of the loaded JSON (via `contents`) rather than loading it directly from a file.  This allows it to be tested properly with an in-memory version.