### PR TITLE
Added github action for running unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Unit Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+   test:
+    name: Run Unit Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+      - name: Install dependencies
+        run: poetry install
+      - name: Test
+        run: poetry run pytest


### PR DESCRIPTION
Part of #16 

This PR introduces a GitHub action to run unit tests on PRs or pushes to the `main` branch.

I don't recall the rules about execution first-time running from a fork into the original repository -- it doesn't show on this PR.  However, you can see it executing in a PR to `main` in my fork here: https://github.com/alanisaac/ocsf-validator/pull/1/checks

The checks will fail until #15 is resolved, so merging this should wait until that is fixed.