### PR TITLE
Add support for defining observables in "patch extends"

### DIFF
--- a/ocsf_validator/types.py
+++ b/ocsf_validator/types.py
@@ -124,9 +124,9 @@ class OcsfProfile(TypedDict):
 OcsfObject = TypedDict(
     "OcsfObject",
     {
-        "caption": str,
-        "description": str,
-        "name": str,
+        "caption": NotRequired[str],
+        "description": NotRequired[str],
+        "name": NotRequired[str],
         "attributes": Dict[str, OcsfAttr],
         "extends": NotRequired[Union[str, list[Optional[str]]]],
         "observable": NotRequired[int],
@@ -143,8 +143,8 @@ OcsfEvent = TypedDict(
     "OcsfEvent",
     {
         "attributes": Dict[str, OcsfAttr],
-        "caption": str,
-        "name": str,
+        "caption": NotRequired[str],
+        "name": NotRequired[str],
         "uid": NotRequired[int],
         "category": NotRequired[str],
         "description": NotRequired[str],


### PR DESCRIPTION
Add support for defining observables in "patch extends" class and object definitions. Also modifies `types.py` and `validations.py` to remove false failures that are legal in class and object definitions of derived classes/objects and patch extends cases.

Related:
* https://github.com/ocsf/ocsf-server/issues/82
* https://github.com/ocsf/ocsf-server/pull/83