### PR TITLE
Cleanup a variety of typing and duplicate errors

### DIFF
--- a/ocsf_validator/errors.py
+++ b/ocsf_validator/errors.py
@@ -196,9 +196,9 @@ class IncludeTypeMismatchError(ValidationError):
         self.file = file
         self.include = include
         if isinstance(t, str):
-            self.cls = t
+            self.cls: str = t
         else:
-            self.cls: str = t.__name__
+            self.cls = t.__name__
         self.directive = directive
         super().__init__(
             f"`{directive}` type mismatch in {file}: expected type `{self.cls}` for {include}"

--- a/ocsf_validator/matchers.py
+++ b/ocsf_validator/matchers.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import re
-from abc import ABC
 from pathlib import Path
 from typing import Optional
 
@@ -11,7 +12,7 @@ class Matcher:
         raise NotImplementedError()
 
     @staticmethod
-    def make(pattern):
+    def make(pattern) -> Matcher:
         if isinstance(pattern, Matcher):
             return pattern
         else:

--- a/ocsf_validator/processor.py
+++ b/ocsf_validator/processor.py
@@ -413,10 +413,10 @@ class IncludeParser(MergeParser):
 class Dependencies:
     """A friendly list of dependencies."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._dependencies: dict[str, list[tuple[str, str]]] = {}
 
-    def add(self, child: str, parent: str, label: str = ""):
+    def add(self, child: str, parent: str, label: str = "") -> None:
         if child not in self._dependencies:
             self._dependencies[child] = []
         self._dependencies[child].append((parent, label))

--- a/ocsf_validator/runner.py
+++ b/ocsf_validator/runner.py
@@ -6,7 +6,7 @@ import traceback
 from dataclasses import dataclass
 from enum import IntEnum
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional
 
 from termcolor import colored
 
@@ -42,7 +42,7 @@ class ValidatorOptions:
     base_path: str = "."
     """The base path of the schema."""
 
-    metaschema_path: str = None
+    metaschema_path: Optional[str] = None
     """The path to the schema's metaschema."""
 
     extensions: bool = True
@@ -204,7 +204,7 @@ class ValidationRunner:
             case _:
                 return self.txt_emphasize("???")
 
-    def validate(self):
+    def validate(self) -> None:
         exit_code = 0
         messages: dict[str, dict[int, set[str]]] = {}
         collector = errors.Collector(throw=False)

--- a/ocsf_validator/type_mapping.py
+++ b/ocsf_validator/type_mapping.py
@@ -5,7 +5,7 @@ from ocsf_validator.matchers import *
 from ocsf_validator.reader import Reader
 from ocsf_validator.types import *
 
-MATCHERS = [
+MATCHERS: list = [
     VersionMatcher(),
     DictionaryMatcher(),
     CategoriesMatcher(),

--- a/ocsf_validator/types.py
+++ b/ocsf_validator/types.py
@@ -113,7 +113,6 @@ class OcsfInclude(TypedDict):
 
 class OcsfProfile(TypedDict):
     caption: str
-    caption: str
     description: str
     meta: str
     name: str

--- a/ocsf_validator/validators.py
+++ b/ocsf_validator/validators.py
@@ -268,7 +268,7 @@ def validate_intra_type_collisions(
 
 
 def _default_get_registry(reader: Reader, base_uri: str) -> referencing.Registry:
-    registry = referencing.Registry()
+    registry: referencing.Registry = referencing.Registry()
     for schema_file_path in reader.metaschema_path.glob("*.schema.json"):
         with open(schema_file_path, "r") as file:
             schema = json.load(file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ocsf-validator"
-version = "0.1.7"
+version = "0.1.8"
 description = "OCSF Schema Validation"
 authors = [
     "Jeremy Fisher <jeremy@query.ai>",

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -123,7 +123,7 @@ def test_extends():
     assert "thing" in r["/events/network/http_activity.json"]["attributes"]
 
 
-def test_profiles():
+def test_profiles_basic():
     prof = event("profile1", ["thing"])
     httpa = event("http_activity")
     httpa["profiles"] = "profile1"

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -363,7 +363,7 @@ def test_validate_metaschemas():
     }
 
     def _get_registry(reader, base_uri) -> referencing.Registry:
-        registry = referencing.Registry()
+        registry: referencing.Registry = referencing.Registry()
         for schema in METASCHEMA_MATCHERS.keys():
             resource = referencing.Resource.from_contents(object_json_schema)
             registry = registry.with_resource(base_uri + schema, resource=resource)


### PR DESCRIPTION
As I was working on addressing #8 and #20, I found a few issues I wanted to cleanup.  To keep those PRs lighter, I created a separate PR here to address them.

These were found mainly by running `mypy` over the codebase.  At some point, we may want to consider running a type checker over the codebase as part of the CI pipeline / GitHub actions.