### PR TITLE
Fixed validation to not merge dependencies into categories

### DIFF
--- a/ocsf_validator/matchers.py
+++ b/ocsf_validator/matchers.py
@@ -122,3 +122,13 @@ class CategoriesMatcher(RegexMatcher, TypeMatcher):
 
     def get_type(self):
         return OcsfCategories
+
+class ExcludeMatcher(Matcher):
+    """
+    A matcher that produces the opposite result of the matcher it's given.
+    """
+    def __init__(self, matcher: Matcher):
+        self.matcher = matcher
+
+    def match(self, value: str) -> bool:
+        return not self.matcher.match(value)

--- a/ocsf_validator/processor.py
+++ b/ocsf_validator/processor.py
@@ -2,6 +2,10 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from ocsf_validator.errors import *
+from ocsf_validator.matchers import (
+    CategoriesMatcher,
+    ExcludeMatcher
+)
 from ocsf_validator.reader import Reader
 from ocsf_validator.type_mapping import TypeMapping
 from ocsf_validator.types import (
@@ -462,7 +466,13 @@ def process_includes(
     fulfilled: set[str] = set()
     dependencies = Dependencies()
 
-    for path in reader.match():
+    # categories cannot be extended with dependencies, and it causes problems
+    # if we try to include dictionary attributes in categories
+    matcher = ExcludeMatcher(
+        CategoriesMatcher()
+    )
+
+    for path in reader.match(matcher):
         for directive, parser in parsers.items():
             if parser.found_in(path):
                 for target in parser.extract_targets(path):

--- a/tests/test_matchers.py
+++ b/tests/test_matchers.py
@@ -42,6 +42,15 @@ def test_extension_matcher():
     assert m.get_type() is OcsfExtension
 
 
+def test_exclude_matcher():
+    m = ExcludeMatcher(
+        ExtensionMatcher()
+    )
+
+    assert m.match("/extensions/ext1/extension.json") is False
+    assert m.match("/extension.json") is True
+
+
 def test_make_matcher():
     m = Matcher.make(".*thing.json")
 


### PR DESCRIPTION
Currently the `ocsf-validator` is treating the `attributes` tag of `categories` the same as any other attributes, which involves merging them with the `dictionary`.  This is incorrect behavior, as attributes of `categories` do not have any of the characteristics imbued by the dictionary.

This is currently causing a problem in https://github.com/ocsf/ocsf-schema/pull/1066, which adds a `remediation` category, because `remediation` is an event attribute elsewhere, with an entry in the `dictionary`.

This PR changes the validator's logic, such that `categories` are skipped when the validator merges in dependencies (a.k.a. `extends`, `profiles`, `includes`, or advanced `attributes`) as `categories` should have none of these.

Tested against the branch from the PR above, and it fixes the original problem:

```
SUMMARY
   PASSED: Schema definitions can be loaded
   PASSED: Schema types can be inferred
   PASSED: Check observable type_id definitions
   PASSED: Dependency targets are resolvable and exist
   PASSED: Required keys are present
   PASSED: There are no unrecognized keys
   PASSED: All attributes in the dictionary are used
   PASSED: All attributes are defined in dictionary.json
   PASSED: Names are not used multiple times within a record type
   PASSED: Attribute type references are defined
   PASSED: Event class categories are defined
   PASSED: JSON files match their metaschema definition
```