### PR TITLE
Enhanced validation messages for key errors.

### DIFF
--- a/ocsf_validator/errors.py
+++ b/ocsf_validator/errors.py
@@ -85,13 +85,8 @@ class MissingRequiredKeyError(ValidationError):
         else:
             trail_str = ".".join(trail)
 
-        if cls is None:
-            cls_str = ""
-        else:
-            cls_str = cls.__name__ + "."
-
         super().__init__(
-            f"Missing required key `{cls_str}{key}` at `{trail_str}` in {file}"
+            f"Missing required key `{key}` at `{trail_str}` in {file}.  Make sure required fields in this file and any supporting files such as dictionaries or includes are populated."
         )
 
 
@@ -113,13 +108,8 @@ class UnknownKeyError(ValidationError):
         else:
             trail_str = ".".join(trail)
 
-        if cls is None:
-            cls_str = ""
-        else:
-            cls_str = cls.__name__
-
         super().__init__(
-            f"Unrecognized key `{key}` of `{cls_str}` at `{trail_str}` in {file}"
+            f"Unrecognized key `{key}` at `{trail_str}` in {file}.  Make sure fields in this file and any supporting files such as dictionaries or includes are valid."
         )
 
 


### PR DESCRIPTION
Fixes #20 

This PR:

* Adds another sentence to the key-based errors in the `ocsf-validator` to help schema developers understand that the errors could be in the source file OR referenced files.
* Removed the "class" part of the message, which would display as `OcsfAttr`.  While this might be useful for debugging the validation library, schema developers would not know what that is referencing unless they checked the code of this library.

Examples:

```sh
   ERROR: Unrecognized key `foo` at `attributes.transaction_uid` in events/network/dhcp.json.  Make sure fields in this file and any supporting files such as dictionaries or includes are valid.
```

```sh
   ERROR: Missing required key `caption` at `attributes.transaction_uid` in events/network/dhcp.json.  Make sure required fields in this file and any supporting files such as dictionaries or includes are populated.
```