### PR TITLE
allows 'lint' flag in attributes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+#  a Dockerfile to containerize the build of ocsf-validator
+#
+#  To build a container:
+#
+#     docker build -t ocsf-validator:latest .
+#
+#  To use it to validate a schema
+#
+#     docker run --rm -v $PWD:/schema ocsf-validator:latest /schema
+#
+
+FROM python:3.11.9-alpine3.19
+
+RUN apk add --no-cache poetry nodejs npm
+
+WORKDIR /src
+ADD . .
+
+RUN poetry install
+RUN poetry run black .
+RUN poetry run isort .
+RUN poetry run pyright ocsf_validator
+RUN poetry run pytest
+
+ENTRYPOINT ["poetry", "run", "python", "-m", "ocsf_validator"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,14 @@ FROM python:3.11.9-alpine3.19
 RUN apk add --no-cache poetry nodejs npm
 
 WORKDIR /src
-ADD . .
 
-RUN poetry install
+# install stuff that doesn't change much
+ADD poetry.lock pyproject.toml .
+RUN poetry install --no-root
+
+# pull in the rest of the code
+ADD . .
+RUN poetry install --only-root
 RUN poetry run black .
 RUN poetry run isort .
 RUN poetry run pyright ocsf_validator

--- a/ocsf_validator/types.py
+++ b/ocsf_validator/types.py
@@ -50,6 +50,7 @@ OcsfAttr = TypedDict(
         "enum": NotRequired[Dict[str, OcsfEnumMember]],
         "group": NotRequired[str],
         "is_array": NotRequired[bool],
+        "lint": NotRequired[Sequence[str]],
         "max_len": NotRequired[int],
         "name": NotRequired[str],
         "notes": NotRequired[str],

--- a/ocsf_validator/types.py
+++ b/ocsf_validator/types.py
@@ -50,7 +50,7 @@ OcsfAttr = TypedDict(
         "enum": NotRequired[Dict[str, OcsfEnumMember]],
         "group": NotRequired[str],
         "is_array": NotRequired[bool],
-        "lint": NotRequired[Sequence[str]],
+        "suppress_checks": NotRequired[Sequence[str]],
         "max_len": NotRequired[int],
         "name": NotRequired[str],
         "notes": NotRequired[str],


### PR DESCRIPTION
This PR adds support for a `lint` flag in dictionary attributes

It also adds a Dockerfile to containerize the build of ocsf-validator.