### PR TITLE
Adding optional "family" string property to events.

### DIFF
--- a/ocsf_validator/types.py
+++ b/ocsf_validator/types.py
@@ -159,6 +159,7 @@ OcsfEvent = TypedDict(
         "uid": NotRequired[int],
         "category": NotRequired[str],
         "description": NotRequired[str],
+        "family": NotRequired[str],
         "extends": NotRequired[Union[str, list[Optional[str]]]],
         "profiles": NotRequired[Sequence[str]],
         "associations": NotRequired[Dict[str, Sequence[str]]],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ocsf-validator"
-version = "0.2.2"
+version = "0.2.3"
 description = "OCSF Schema Validation"
 authors = [
     "Jeremy Fisher <jeremy@query.ai>",


### PR DESCRIPTION
This adds the new `family` property of events to the types definition to fix a failing unrecognized key check in `ocsf-schema` #1260.