### PR TITLE
Add references and @deprecated support to OcsfProfile

### DIFF
--- a/ocsf_validator/types.py
+++ b/ocsf_validator/types.py
@@ -128,13 +128,19 @@ class OcsfInclude(TypedDict):
     annotations: NotRequired[Dict[str, str]]
 
 
-class OcsfProfile(TypedDict):
-    caption: str
-    description: str
-    meta: str
-    name: str
-    attributes: Dict[str, OcsfAttr]
-    annotations: NotRequired[Dict[str, str]]
+OcsfProfile = TypedDict(
+    "OcsfProfile",
+    {
+        "caption": str,
+        "description": str,
+        "meta": str,
+        "name": str,
+        "attributes": Dict[str, OcsfAttr],
+        "annotations": NotRequired[Dict[str, str]],
+        "references": NotRequired[OcsfReferences],
+        "@deprecated": NotRequired[OcsfDeprecationInfo],
+    },
+)
 
 
 OcsfObject = TypedDict(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ocsf-validator"
-version = "0.2.3"
+version = "0.2.4"
 description = "OCSF Schema Validation"
 authors = [
     "Jeremy Fisher <jeremy@query.ai>",


### PR DESCRIPTION
This adds the references and @deprecated properties to the OcsfProfile type definition to fix a failing unrecognized key check. The profile metaschema (profile.schema.json) already defines both properties, but the validator's OcsfProfile TypedDict was missing them, causing the "no unknown keys" check to fail when a profile uses references.

Converted OcsfProfile from class-based TypedDict to functional form (consistent with OcsfObject and OcsfEvent) since @deprecated is not a valid Python identifier.

Bumps version to 0.2.4.

Related to https://github.com/ocsf/ocsf-schema/pull/1616

--

Tested locally, runs as expected. 